### PR TITLE
Don't import scipy until needed

### DIFF
--- a/dinf/dinf.py
+++ b/dinf/dinf.py
@@ -9,7 +9,6 @@ import signal
 from typing import Callable, Iterable, Protocol, Tuple
 import zipfile
 
-import emcee
 import jax
 import numpy as np
 from numpy.lib.recfunctions import structured_to_unstructured
@@ -722,6 +721,9 @@ def _run_mcmc_emcee(
     ss: np.random.SeedSequence,
     callbacks: dict | None = None,
 ):
+    # Emcee imports scipy, which takes ages, so import only when needed.
+    import emcee
+
     if callbacks is None:
         callbacks = {}
     assert all(k in ("mcmc",) for k in callbacks)

--- a/dinf/parameters.py
+++ b/dinf/parameters.py
@@ -6,7 +6,6 @@ import logging
 from typing import Tuple
 
 import numpy as np
-import scipy
 
 logger = logging.getLogger(__name__)
 
@@ -468,6 +467,9 @@ class Parameters(collections.abc.Mapping):
         :return:
             Median position in multivariate space.
         """
+
+        # Scipy import takes ages, so import only when needed.
+        import scipy
 
         # Normalize by mean/stddev so each parameter is treated equally
         # in the objective function.


### PR DESCRIPTION
Jax 0.3.24 now does lazy imports of scipy, which speeds up 'import jax' tremendously. So this commit changes dinf to do lazy scipy imports. We have to jump through a few hoops, but this drops 400-500 ms off the time that the CLI takes to just show help. 'import jax' is still the worst offender, taking 350 ms, but this is a massive win!

Part of #195.