### PR TITLE
Use codecov token

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -79,3 +79,6 @@ jobs:
         with:
           fail_ci_if_error: true
           env_vars: OS,PYTHON
+          # Use upload token to avoid upload failures.
+          # https://github.com/codecov/codecov-action/issues/837
+          token: d515a3c4-c5cd-4d0f-8bb1-0ebca0450c5a


### PR DESCRIPTION
Codecov says that tokens aren't necessary for public repos. While this is true, it is also problematic. Without a token, codecov queries the Github Actions API to determine the originating repository for the upload. Unfortunately, this API is rate limited, and the limit appears to be exceeded fairly often, which results in a failure to upload the codecov report:

```
There was an error running the uploader: Error uploading to https://codecov.io: Error: There was an error fetching the storage URL during POST: 404 - {'detail': ErrorDetail(string='Unable to locate build via Github Actions API. Please upload with the Codecov repository upload token to resolve issue.', code='not_found')}
```

By setting the repository token, codecov should skip this step.